### PR TITLE
add link to about in nav

### DIFF
--- a/app/views/layouts/shared/_nav.html.erb
+++ b/app/views/layouts/shared/_nav.html.erb
@@ -1,4 +1,4 @@
 <% if signed_in? %>
- <%= link_to "About", "#" %>
+ <%= link_to "About", "about" %>
   <%= link_to "Sign out", destroy_user_session_path %>
 <% end %>


### PR DESCRIPTION
The about link had a placeholder and now links to the actual about page.